### PR TITLE
Refactor morpheval for tokenizer compatibility

### DIFF
--- a/morphscore.py
+++ b/morphscore.py
@@ -1,25 +1,21 @@
 import pandas as pd
 import numpy as np
 
-def morph_eval(morphemes, tokens): #returns -1,0, 1
-    point = -1
+def morph_eval(morphemes, tokens):
+    """
+    Returns 1 if the morphemes are correctly segmented by the tokenizer,
+    0 if they are not segmented correctly, and -1 if the full word is already
+    present in the tokenizer's vocabulary.
+    """
     if len(tokens) == 1:
-        point = 0
-    else:
-        segment_score = 0
-        for t in range(len(tokens)-1):
-            pt1 = ''.join(tokens[:t+1])
-            rest = ''.join(tokens[t+1:])
-            segments = [pt1, rest]
-            if segments == morphemes:
-                segment_score += 1
-            else:
-                segment_score += 0
-        if segment_score == 1:
-            point = 1
-        else:
-            point = -1
-    return point
+        return -1
+    for t in range(len(tokens)-1):
+        pt1 = ''.join(tokens[:t+1])
+        rest = ''.join(tokens[t+1:])
+        segments = [pt1, rest]
+        if segments == morphemes:
+            return 1
+    return 0
 
 def get_morphscore(language, tokenizer):
     dataset = pd.read_csv(f'morphscore/data/{language}_morph_data.csv')
@@ -29,22 +25,18 @@ def get_morphscore(language, tokenizer):
         rest = dataset.iloc[d]['rest']
         morphemes = [pt1, rest]
         full_word = dataset.iloc[d]['full_word']
-        tokens = tokenizer(full_word)['input_ids']
-
-        vocab_size = tokenizer.vocab_size
-        spc_tok1 = int(vocab_size)
-        spc_tok2 = int(vocab_size) + 1
-        if spc_tok1 in tokens:
-            tokens.remove(spc_tok1)
-        if spc_tok2 in tokens:
-            tokens.remove(spc_tok2)
-
+        tokens = tokenizer(full_word, add_special_tokens=False)['input_ids']
         tokens = [tokenizer.decode(t) for t in tokens]
-        point = morph_eval(morphemes, tokens)
 
+        # Remove special prefixes added by common tokenizers like BPE or Wordpiece
+        tokens = [token.strip('_').strip('Ġ').strip('##').strip() for token in tokens]
+        tokens = [token for token in tokens if token != '']
+        
+        # Compare gold morphemes with tokenizer tokens for alignment
+        point = morph_eval(morphemes, tokens)
         points.append(point)
 
-    points = [x for x in points if x != 0]
-    points= [0 if x == -1 else x for x in points]
+    # Skip words if they are already included in the tokenizer's vocabulary
+    points = [x for x in points if x != -1]
     morph_score = np.mean(points)
     return morph_score


### PR DESCRIPTION
Decoded tokens are stripped of prefixes produced by common tokenizer models like BPE and WordPiece. Additionally, the code is slightly refactored for simplicity and comments are added for readability.

`morph_eval` is also adjusted to return -1 for invalid words and 0 for incorrect segmentations, making it easier to filter the invalid words at the end (no need to remap -1 values to 0). 

This should address Issue #1.